### PR TITLE
fix: warning & error message

### DIFF
--- a/obniz/obniz/libs/io_peripherals/io.py
+++ b/obniz/obniz/libs/io_peripherals/io.py
@@ -91,20 +91,20 @@ class PeripheralIO:
             if self.onchange:
                 self.onchange(obj)
 
-        elif type(obj) is object:
-            if obj.warning:
+        elif type(obj) is dict:
+            if obj.get('warning'):
                 self.obniz.warning(
                     {
                         "alert": "warning",
-                        "message": "io{}: {}".format(self.id, obj.warning.message),
+                        "message": "io{}: {}".format(self.id, obj['warning']['message']),
                     }
                 )
 
-            if obj.error:
+            if obj.get('error'):
                 self.obniz.error(
                     {
                         "alert": "error",
-                        "message": "io{}}: {}".format(self.id, obj.error.message),
+                        "message": "io{}}: {}".format(self.id, obj['error']['message']),
                     }
                 )
 

--- a/obniz/obniz/obniz_connection.py
+++ b/obniz/obniz/obniz_connection.py
@@ -470,7 +470,7 @@ class ObnizConnection:
     #   }
 
     def warning(self, msg):
-        print("warning:" + str(msg))
+        print(str(msg["message"]))
 
     def error(self, msg):
-        print("error:" + str(msg))
+        print(str(msg["message"]))


### PR DESCRIPTION
- pythonSDKでio heavy outputが表示されない問題の対処です。
  - `obj`がdict型の場合に動作するよう編集しました。
- ショート時の出力↓
```
warning:{'alert': 'warning', 'message': 'io0: heavy output. output voltage is too low 
when driving high'}
```